### PR TITLE
Added -all parameter to generate docs for unexported methods.

### DIFF
--- a/godocdown/main.go
+++ b/godocdown/main.go
@@ -25,6 +25,10 @@ http://github.com/robertkrimen/godocdown/blob/master/example.markdown
 
 Usage
 
+    -all=false                                                                       
+        Generate documentation for all package level declarations,                   
+        not just exported declarations.                                              
+
     -output=""                                                                       
         Write output to a file instead of stdout                                     
         Write to stdout with -                                                       
@@ -127,6 +131,7 @@ var (
 	flag_heading    = flag.String("heading", "TitleCase1Word", "Heading detection method: 1Word, TitleCase, Title, TitleCase1Word, \"\"")
 	flag_template   = flag.String("template", "", "The template file to use")
 	flag_noTemplate = flag.Bool("no-template", false, "Disable template processing")
+	flag_all        = flag.Bool("all", false, "Document all code, not just exported code")
 	flag_output     = ""
 	_               = func() byte {
 		flag.StringVar(&flag_output, "output", flag_output, "Write output to a file instead of stdout. Write to stdout with -")
@@ -231,6 +236,14 @@ func indentCode(target string) string {
 		return indent(target+"\n", spacer(4))
 	}
 	return fmt.Sprintf("```go\n%s\n```", target)
+}
+
+func docMode() doc.Mode {
+	if *flag_all {
+		return doc.AllDecls
+	} else {
+		return doc.Mode(0)
+	}
 }
 
 func headifySynopsis(target string) string {
@@ -383,7 +396,7 @@ func loadDocument(target string) (*_document, error) {
 		// Choose the best package for documentation. Either
 		// documentation, main, or whatever the package is.
 		for _, parsePkg := range pkgSet {
-			tmpPkg := doc.New(parsePkg, ".", 0)
+			tmpPkg := doc.New(parsePkg, ".", docMode())
 			switch tmpPkg.Name {
 			case "main":
 				if isCommand || name != "" {


### PR DESCRIPTION
Added `-all` parameter which allows generation of documentation for unexported methods.

Running `godocdown` on a simple example returns:

``````
# test
--
    import "."


## Usage

#### func  Asdf

```go
func Asdf()
```
Exported documentation
``````

Whereas running `godocdown -all` returns:

``````
# test
--
    import "."


## Usage

#### func  Asdf

```go
func Asdf()
```
Exported documentation

#### func  asdf

```go
func asdf()
```
Unexported documentation
``````
