### PR TITLE
skip pkg_test imports

### DIFF
--- a/godocdown/main.go
+++ b/godocdown/main.go
@@ -404,6 +404,10 @@ func loadDocument(target string) (*_document, error) {
 				isCommand = true
 				pkg = tmpPkg
 			default:
+				// test import, like pkg_test
+				if strings.HasSuffix(tmpPkg.Name, "_test") {
+					continue
+				}
 				// Just a regular package
 				name = tmpPkg.Name
 				pkg = tmpPkg


### PR DESCRIPTION
For example in `gopkg.in/rana/ora.v4`, some tests are internal (`package ora`), some tests external (`package ora_test`). The latter results in wrong import path, and this is random, as it depends on which file was read first in the for cycle!

This CL skips package names with `_test` suffix.