### PR TITLE
Update README: Change go get to go install for Go 1.16+ compatibility

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@
 Command godocdown generates Go documentation in a GitHub-friendly Markdown
 format.
 
-    $ go get github.com/robertkrimen/godocdown/godocdown
+    $ go install github.com/robertkrimen/godocdown/godocdown@latest
 
     $ godocdown /path/to/package > README.markdown
 
@@ -20,7 +20,7 @@ changed with the use of the "plain" flag to generate standard Markdown.
 
 ### Install
 
-    go get github.com/robertkrimen/godocdown/godocdown
+    go install github.com/robertkrimen/godocdown/godocdown@latest
 
 
 ### Example

--- a/godocdown/main.go
+++ b/godocdown/main.go
@@ -1,7 +1,7 @@
 /*
 Command godocdown generates Go documentation in a GitHub-friendly Markdown format.
 
-    $ go get github.com/robertkrimen/godocdown/godocdown                         
+    $ go install github.com/robertkrimen/godocdown/godocdown@latest                       
                                                                                  
     $ godocdown /path/to/package > README.markdown                               
                                                                                  
@@ -17,7 +17,7 @@ default. This can be changed with the use of the "plain" flag to generate standa
 
 Install
 
-    go get github.com/robertkrimen/godocdown/godocdown
+    go install github.com/robertkrimen/godocdown/godocdown@latest
 
 Example
 


### PR DESCRIPTION
This PR updates the installation instructions in the README to reflect the changes introduced in Go 1.16. The current `go get` command no longer installs the binary when using the module mode, which is now the default for Go. 

The proposed change uses `go install`:
```bash
go install github.com/robertkrimen/godocdown/godocdown@latest
```
This will ensure that the binary is correctly installed to `GOBIN` (or `GOPATH/bin` if `GOBIN` is not set).

**Why this change is necessary**:
- The `go get` command as it currently stands in the README only downloads the source code without installing the executable in Go 1.16+.
- Using `go install` is the recommended way to install binaries from a module in Go 1.16 and later.